### PR TITLE
fix(config): use ~/.config/ for storage on all platforms

### DIFF
--- a/src/config/discovery.rs
+++ b/src/config/discovery.rs
@@ -72,8 +72,8 @@ pub fn discover_verbose() -> (DiscoveryResult, Vec<PathBuf>) {
     let mut searched_paths = Vec::new();
 
     // Check global config first
-    if let Some(config_dir) = dirs::config_dir() {
-        let global_config_path = config_dir.join("lazytail").join(GLOBAL_CONFIG_NAME);
+    if let Some(lazytail_dir) = crate::source::lazytail_dir() {
+        let global_config_path = lazytail_dir.join(GLOBAL_CONFIG_NAME);
         if global_config_path.try_exists().unwrap_or(false) && global_config_path.is_file() {
             result.global_config = Some(global_config_path);
         }

--- a/src/history.rs
+++ b/src/history.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 /// Get the history file path
 fn history_file_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|p| p.join("lazytail").join("history.json"))
+    crate::source::lazytail_dir().map(|p| p.join("history.json"))
 }
 
 /// Load filter history from disk


### PR DESCRIPTION
## Summary

- Use `~/.config/lazytail/` for storage on all platforms instead of platform-specific directories
- On macOS, `dirs::config_dir()` returns `~/Library/Application Support/` which is inconvenient for CLI tools
- Added `lazytail_dir()` helper using `dirs::home_dir()` + `.config/lazytail` for consistent cross-platform paths
- Updated all call sites: source discovery, history, and config discovery

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes  
- [x] `cargo test` — 434 fast tests pass
- [x] `cargo test -- --include-ignored` — all 465 tests pass