### PR TITLE
feat(ui): display file path in header and add y to copy source path

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -78,6 +78,7 @@ pub enum AppEvent {
     SourcePanelDown,
     ToggleCategoryExpand,
     SelectSource,
+    CopySourcePath,
 
     // Mode toggles
     ToggleFollowMode,

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -116,6 +116,7 @@ fn handle_source_panel_mode(key: KeyEvent) -> Vec<AppEvent> {
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             vec![AppEvent::Quit]
         }
+        KeyCode::Char('y') => vec![AppEvent::CopySourcePath],
         KeyCode::Char('?') => vec![AppEvent::ShowHelp],
         _ => vec![],
     }


### PR DESCRIPTION
## Summary

- Display the full file path next to the stream name in the log view header/title bar (e.g. `mylog — /path/to/mylog.log`)
- Add `y` keybinding in the source panel to copy the selected source's file path to clipboard (via OSC 52)
- Show a temporary green status message ("Copied: /path/...") in the status bar for 3 seconds after copying
- Update help overlay with the new keybinding

## Test plan

- [ ] Open a file and verify the header shows `filename — /full/path/to/file`
- [ ] Open multiple sources, switch tabs, verify each shows its own path
- [ ] Focus source panel (Tab), select a source, press `y` — verify path is copied to clipboard
- [ ] Verify status bar shows green "Copied: ..." message that disappears after ~3s
- [ ] Press `?` and verify `y  Copy source path` appears under Source Panel
- [ ] Verify stdin/pipe sources show name only (no path suffix)