### PR TITLE
feat(mcp): accept source names instead of file paths in tool API

### DIFF
--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -27,11 +27,11 @@ fn default_context() -> usize {
     5
 }
 
-/// Request to fetch lines from a log file.
+/// Request to fetch lines from a lazytail source.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetLinesRequest {
-    /// Path to the log file
-    pub file: PathBuf,
+    /// Source name (from list_sources)
+    pub source: String,
     /// Starting line number (0-indexed)
     #[serde(default)]
     pub start: usize,
@@ -79,11 +79,11 @@ pub enum SearchMode {
     Regex,
 }
 
-/// Request to search for patterns in a log file.
+/// Request to search for patterns in a lazytail source.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchRequest {
-    /// Path to the log file
-    pub file: PathBuf,
+    /// Source name (from list_sources)
+    pub source: String,
     /// Search pattern
     pub pattern: String,
     /// Search mode: "plain" or "regex" (default: plain)
@@ -136,11 +136,11 @@ pub struct SearchMatch {
     pub after: Vec<String>,
 }
 
-/// Request to fetch the last N lines from a log file.
+/// Request to fetch the last N lines from a lazytail source.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetTailRequest {
-    /// Path to the log file
-    pub file: PathBuf,
+    /// Source name (from list_sources)
+    pub source: String,
     /// Number of lines to fetch from the end (default 100, max 1000)
     #[serde(default = "default_count")]
     pub count: usize,
@@ -152,11 +152,11 @@ pub struct GetTailRequest {
     pub output: OutputFormat,
 }
 
-/// Request to get context around a specific line.
+/// Request to get context around a specific line in a lazytail source.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetContextRequest {
-    /// Path to the log file
-    pub file: PathBuf,
+    /// Source name (from list_sources)
+    pub source: String,
     /// The target line number (0-indexed)
     pub line_number: usize,
     /// Number of lines before the target (default 5, max 50)


### PR DESCRIPTION
## Summary

- MCP tools (`get_lines`, `get_tail`, `search`, `get_context`) now accept a `source` name (string) instead of a `file` path, preventing misuse on arbitrary files
- Added `resolve_source_in()` and `resolve_source()` to `source.rs` for validated name→path resolution
- Extracted `_impl` static methods in `tools.rs` so tests operate on paths directly while tool wrappers handle source resolution

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes (no warnings)
- [x] `cargo test` — 437 fast tests pass
- [x] `cargo test -- --ignored` — 31 slow integration tests pass
- [ ] CI passes