### PR TITLE
fix(capture): clean up stale markers from killed processes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,45 +36,61 @@ cargo run --release -- test.log
 
 ```
 src/
-├── main.rs                # Entry point, CLI (clap), and main event loop
-├── app.rs                 # Application state management
-├── tab.rs                 # Per-tab state (reader, watcher, filter, viewport)
-├── viewport.rs            # Vim-style viewport scrolling
-├── event.rs               # Event type definitions
-├── watcher.rs             # File watching with inotify
-├── dir_watcher.rs         # Directory watcher for source discovery
-├── capture.rs             # Capture mode (tee-like stdin to file)
-├── source.rs              # Source discovery and status tracking
-├── signal.rs              # Signal handling (SIGINT/SIGTERM)
-├── history.rs             # Filter history persistence
-├── cache/                 # Line and ANSI caching
-├── cmd/                   # CLI subcommands (init, config)
-├── config/                # Config system (lazytail.yaml discovery + loading)
+├── main.rs                 # Entry point, CLI (clap), and main event loop
+├── app.rs                  # Application state management
+├── tab.rs                  # Per-tab state (reader, watcher, filter, viewport)
+├── viewport.rs             # Vim-style viewport scrolling
+├── event.rs                # Event type definitions
+├── watcher.rs              # File watching with inotify
+├── dir_watcher.rs          # Directory watcher for source discovery
+├── capture.rs              # Capture mode (tee-like stdin to file)
+├── source.rs               # Source discovery and status tracking
+├── signal.rs               # Signal handling (SIGINT/SIGTERM)
+├── history.rs              # Filter history persistence
+├── cache/
+│   ├── mod.rs              # Cache module
+│   ├── line_cache.rs       # LRU cache for line content
+│   └── ansi_cache.rs       # ANSI-parsed line cache
+├── cmd/
+│   ├── mod.rs              # CLI subcommand definitions
+│   ├── init.rs             # `lazytail init` command
+│   └── config.rs           # `lazytail config` commands
+├── config/
+│   ├── mod.rs              # Config module
+│   ├── discovery.rs        # Walk parent dirs for lazytail.yaml
+│   ├── loader.rs           # YAML config loading
+│   ├── types.rs            # Config structs
+│   └── error.rs            # Config error types
 ├── filter/
-│   ├── mod.rs             # Filter trait
-│   ├── engine.rs          # Background filtering engine
-│   ├── streaming_filter.rs# Streaming mmap-based filter (grep-like)
-│   ├── regex_filter.rs    # Regex filter implementation
-│   ├── string_filter.rs   # String matching filter
-│   ├── query.rs           # Query language (json | field == value)
-│   ├── cancel.rs          # Cancellation tokens
-│   └── parallel_engine.rs # Parallel filtering
-├── handlers/              # Input, filter progress, file event handlers
-├── mcp/                   # MCP server for AI assistant integration
-│   ├── tools.rs           # Tool implementations (5 tools)
-│   ├── types.rs           # Request/response types
-│   ├── format.rs          # Plain text output formatters
-│   └── ansi.rs            # ANSI escape code stripping
+│   ├── mod.rs              # Filter trait
+│   ├── engine.rs           # Background filtering engine
+│   ├── streaming_filter.rs # Streaming mmap-based filter (grep-like)
+│   ├── regex_filter.rs     # Regex filter implementation
+│   ├── string_filter.rs    # String matching filter
+│   ├── query.rs            # Query language (json | field == value)
+│   ├── cancel.rs           # Cancellation tokens
+│   └── parallel_engine.rs  # Parallel filtering
+├── handlers/
+│   ├── mod.rs              # Handler module
+│   ├── input.rs            # Keyboard input handling
+│   ├── filter.rs           # Filter progress handling
+│   └── file_events.rs      # File change event handling
+├── mcp/
+│   ├── mod.rs              # MCP server module
+│   ├── tools.rs            # Tool implementations (5 tools)
+│   ├── types.rs            # Request/response types
+│   ├── format.rs           # Plain text output formatters
+│   └── ansi.rs             # ANSI escape code stripping
 ├── reader/
-│   ├── mod.rs             # LogReader trait
-│   ├── file_reader.rs     # Lazy file reader with line indexing
-│   ├── stream_reader.rs   # Stdin/stream reader
-│   ├── mmap_reader.rs     # Memory-mapped reader
-│   ├── huge_file_reader.rs# Large file support
-│   ├── sparse_index.rs    # Sparse line index
-│   └── tail_buffer.rs     # Tail buffer for recent lines
+│   ├── mod.rs              # LogReader trait
+│   ├── file_reader.rs      # Lazy file reader with line indexing
+│   ├── stream_reader.rs    # Stdin/stream reader
+│   ├── mmap_reader.rs      # Memory-mapped reader
+│   ├── huge_file_reader.rs # Large file support
+│   ├── sparse_index.rs     # Sparse line index
+│   └── tail_buffer.rs      # Tail buffer for recent lines
 └── ui/
-    └── mod.rs             # ratatui rendering (log view, panels, help overlay)
+    └── mod.rs              # ratatui rendering (log view, panels, help overlay)
 ```
 
 For detailed architecture documentation, see `CLAUDE.md`.

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -10,8 +10,8 @@
 use crate::config::DiscoveryResult;
 use crate::signal::setup_shutdown_handlers;
 use crate::source::{
-    check_source_status_for_context, create_marker_for_context, ensure_directories_for_context,
-    remove_marker_for_context, resolve_data_dir, validate_source_name, SourceStatus,
+    create_marker_for_context, ensure_directories_for_context, remove_marker_for_context,
+    resolve_data_dir, validate_source_name,
 };
 use anyhow::{Context, Result};
 use std::fs::OpenOptions;
@@ -40,15 +40,7 @@ pub fn run_capture_mode(name: String, discovery: &DiscoveryResult) -> Result<()>
     // 2. Ensure directories exist using context
     ensure_directories_for_context(discovery)?;
 
-    // 3. Check for collision
-    if check_source_status_for_context(&name, discovery) == SourceStatus::Active {
-        anyhow::bail!(
-            "Source '{}' is already active (another process is writing to it)",
-            name
-        );
-    }
-
-    // 4. Create marker file with our PID
+    // 3. Create marker file with our PID (cleans stale markers, rejects active sources)
     create_marker_for_context(&name, discovery)?;
 
     // 5. Setup signal handlers (flag-based, supports double Ctrl+C for force quit)


### PR DESCRIPTION
## Summary

- Fix stale marker files preventing capture mode restart after SIGKILL/OOM
- `create_marker_for_context` now detects stale markers (PID not running) and removes them before creating new ones
- Remove redundant collision check from `capture.rs` (now handled atomically in marker creation)
- Update `CONTRIBUTING.md` project file tree to include all current modules

## Test plan

- [x] `cargo test` — 447 passed, 0 failed
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [x] New test `test_stale_marker_cleaned_on_create` verifies stale marker recovery
- [ ] Manual: kill a `lazytail -n test` process, verify restart works