### PR TITLE
fix(mcp): resolve sources from project-local data directory

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,3 +18,22 @@ jobs:
         with:
           release-type: rust
           package-name: lazytail
+
+      - name: Update release notes from PR description
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          PR_NUMBER: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body --jq '.body')
+          if [ -n "$PR_BODY" ]; then
+            gh release edit "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --notes "$PR_BODY"
+          fi
+
+      - name: Trigger release build
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: gh workflow run release.yml --repo "$GITHUB_REPOSITORY" -f tag="$TAG_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -82,7 +80,7 @@ jobs:
     - name: Upload Release Asset
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+        tag_name: ${{ github.event.inputs.tag }}
         files: ./${{ matrix.asset_name }}.tar.gz
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -218,6 +218,8 @@ pub struct SourceInfo {
     pub status: SourceStatus,
     /// File size in bytes
     pub size_bytes: u64,
+    /// Where the source was found (project-local or global)
+    pub location: SourceLocation,
 }
 
 /// Status of a log source.
@@ -228,4 +230,14 @@ pub enum SourceStatus {
     Active,
     /// Source capture has ended (file still available)
     Ended,
+}
+
+/// Location where a source was discovered.
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceLocation {
+    /// Source is in project-local .lazytail/data/
+    Project,
+    /// Source is in global ~/.config/lazytail/data/
+    Global,
 }


### PR DESCRIPTION
## Summary
- MCP tools now resolve sources from project-local `.lazytail/data/` first, falling back to global `~/.config/lazytail/data/`. Project sources shadow global ones with the same name.
- `list_sources` reports source location (project vs global) and the `LazyTailMcp` struct caches config discovery at startup.
- Release workflow updated: PR description used as release notes, release build triggered from release-please, removed `release: published` event trigger.
- Removed dead code (`discover_sources`, `resolve_source`) replaced by `_for_context` variants.

## Test plan
- [x] `cargo test` — 447 passed
- [x] `cargo clippy` — 0 warnings
- [x] `cargo fmt` — clean
- [ ] CI passes