### PR TITLE
fix(ci): trigger release build on tag push instead of workflow dispatch

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -34,9 +34,3 @@ jobs:
             gh release edit "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --notes "$PR_BODY"
           fi
 
-      - name: Trigger release build
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
-        run: gh workflow run release.yml --repo "$GITHUB_REPOSITORY" -f tag="$TAG_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
@@ -10,6 +13,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 permissions:
   contents: write
@@ -80,7 +84,7 @@ jobs:
     - name: Upload Release Asset
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ github.event.inputs.tag }}
+        tag_name: ${{ env.TAG }}
         files: ./${{ matrix.asset_name }}.tar.gz
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix release build not triggering: `GITHUB_TOKEN` lacks permission to dispatch workflows (`HTTP 403`)
- Add `push: tags: v*` trigger to `release.yml` so it runs automatically when release-please creates a tag
- Remove the now-unnecessary `gh workflow run` dispatch step from `release-pr.yml`
- Use `github.event.inputs.tag || github.ref_name` so both tag push and manual dispatch work

## Test plan

- [x] v0.5.3 release build manually triggered to upload missing binaries
- [ ] Verify next release auto-triggers build on tag push