### PR TITLE
fix(source): check project-local markers for TUI source status

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -610,7 +610,13 @@ fn run_app_with_discovery<B: ratatui::backend::Backend>(
                             // Extract name from path
                             if let Some(stem) = path.file_stem() {
                                 let name = stem.to_string_lossy().to_string();
-                                let status = source::check_source_status(&name);
+                                let status = path
+                                    .parent()
+                                    .and_then(|d| d.parent())
+                                    .map(|base| base.join("sources"))
+                                    .filter(|s| s.exists())
+                                    .map(|s| source::check_source_status_in_dir(&name, &s))
+                                    .unwrap_or_else(|| source::check_source_status(&name));
                                 let source = source::DiscoveredSource {
                                     name,
                                     log_path: path,

--- a/src/source.rs
+++ b/src/source.rs
@@ -241,7 +241,7 @@ fn scan_data_directory(
 }
 
 /// Check the status of a source by name in a specific sources directory.
-fn check_source_status_in_dir(name: &str, sources_dir: &Path) -> SourceStatus {
+pub fn check_source_status_in_dir(name: &str, sources_dir: &Path) -> SourceStatus {
     let marker_path = sources_dir.join(name);
     if !marker_path.exists() {
         return SourceStatus::Ended;


### PR DESCRIPTION
## Summary

- Fix TUI showing all sources as ended/inactive when running in a project context
- `refresh_source_status()` was using global-only `check_source_status()` which only checked `~/.config/lazytail/sources/` for markers
- Capture mode creates markers in project-local `.lazytail/sources/` via `create_marker_for_context()`, so the TUI never found them
- Now derives the correct sources directory from the log file path (sibling of data dir), falling back to global
- Made `check_source_status_in_dir` public for reuse
- Also fixed the same issue in the directory watcher's new-source handler in main.rs

## Test plan

- [x] `cargo test` — 447 passed
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [ ] Verify on macOS that project-local sources show correct active/ended status