### PR TITLE
fix(watcher): TUI not refreshing on macOS due to missed file events

### DIFF
--- a/src/watcher/file.rs
+++ b/src/watcher/file.rs
@@ -24,11 +24,10 @@ impl FileWatcher {
         let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
             match res {
                 Ok(event) => {
-                    // Only care about modify events
-                    if matches!(
-                        event.kind,
-                        notify::EventKind::Modify(_) | notify::EventKind::Create(_)
-                    ) {
+                    // Accept any event that could indicate file content changed.
+                    // macOS FSEvents may deliver events as Any or Access rather than
+                    // the specific Modify/Create variants that inotify uses on Linux.
+                    if !matches!(event.kind, notify::EventKind::Remove(_)) {
                         let _ = tx.send(FileEvent::Modified);
                     }
                 }


### PR DESCRIPTION
## Summary

- Broadened file watcher event filter to accept all non-Remove events (macOS FSEvents delivers events with different `EventKind` variants than Linux inotify, causing them to be silently dropped)
- Added periodic file size poll (1s interval) as a safety net for when the OS file watcher misses events entirely
- Applied the same fixes to the web server's file event processing, including a missing `file_size` update after reload

## Test plan

- [ ] Verify TUI refreshes on new log lines on macOS
- [ ] Verify TUI still refreshes correctly on Linux (no regression)
- [ ] Verify web server picks up new log lines on macOS
- [ ] Run `cargo test` — all 489 tests pass