### PR TITLE
feat(help): add scrollable help overlay with j/k navigation

### DIFF
--- a/src/app/event.rs
+++ b/src/app/event.rs
@@ -87,6 +87,8 @@ pub enum AppEvent {
     // Help mode
     ShowHelp,
     HideHelp,
+    ScrollHelpDown,
+    ScrollHelpUp,
 
     // Line jump events
     StartLineJumpInput,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -51,8 +51,8 @@ pub fn render(f: &mut Frame, app: &mut App) -> Result<()> {
     }
 
     // Render help overlay on top of everything if active
-    if app.show_help {
-        help::render_help_overlay(f, f.area());
+    if let Some(scroll_offset) = app.help_scroll_offset {
+        help::render_help_overlay(f, f.area(), scroll_offset);
     }
 
     // Render close confirmation dialog on top of everything if active


### PR DESCRIPTION
## Summary
- Replace `show_help: bool` with `help_scroll_offset: Option<usize>` to track scroll position
- Add `j`/`k`/`↑`/`↓` keys to scroll through help content when overlay is visible
- Show `↑`/`↓` arrow indicators in the help title bar when more content exists above/below
- Clamp scroll offset so content can't scroll past the end

## Test plan
- [x] All 490 existing tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [ ] Open help with `?`, verify j/k scrolls content
- [ ] Verify arrow indicators appear/disappear at content boundaries
- [ ] Verify other keys still close the overlay
- [ ] Verify q/Ctrl+C still quits from help