### PR TITLE
fix(index): detect and reject stale columnar indexes on file replacement

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -240,6 +240,7 @@
 
 ### Capture Mode
 
+- [ ] Keybinding to rebuild/reindex the current source's columnar index (useful when index is stale or corrupted) 🟡
 - [ ] Truncate log file by default on `lazytail -n` (add `--append`/`-a` to keep old behavior) 🟡
 - [ ] Session ID per capture run (UUID in marker + log boundary marker + filter by session) 🟡
 - [ ] `--file <path>` for custom log file location 🟡


### PR DESCRIPTION
## Summary
- Add spot-check validation that verifies indexed line offsets align with actual newlines in the log file
- `FileReader::try_seed_from_index()` now rejects stale indexes and falls back to sparse index scanning
- `capture.rs` validates index consistency before resuming, creates fresh index if stale
- Prevents corrupted/fragmented line display when a log file is deleted and recreated with different content while the old `.idx/` directory survives

## Test plan
- [x] New test `test_stale_index_rejected_on_file_replacement` verifies stale index is rejected
- [x] All existing tests pass (785 tests)
- [x] Clippy clean, fmt clean
- [x] Manually verified: deleted stale `fast.idx`, source now reads correctly