### PR TITLE
feat(renderer): add capture rendering, theme-aware styles, and external presets

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -264,7 +264,10 @@ impl LazyTailMcp {
             Ok(cfg) => {
                 // Compilation errors are intentionally discarded — the MCP server has no
                 // stderr channel. Invalid renderers are simply omitted from the registry.
-                let (registry, _errors) = PresetRegistry::compile_from_config(&cfg.renderers);
+                let (registry, _errors) = PresetRegistry::compile_from_config(
+                    &cfg.renderers,
+                    discovery.project_root.as_deref(),
+                );
                 let map: HashMap<String, Vec<String>> = cfg
                     .project_sources
                     .iter()
@@ -2012,7 +2015,7 @@ plain line with no escapes\n\
             ],
         }];
 
-        let (registry, _) = crate::renderer::PresetRegistry::compile_from_config(&renderers);
+        let (registry, _) = crate::renderer::PresetRegistry::compile_from_config(&renderers, None);
         let mut source_renderer_map = HashMap::new();
         source_renderer_map.insert(file_stem.to_string(), vec!["json".to_string()]);
         LazyTailMcp {
@@ -2110,7 +2113,7 @@ plain line with no escapes\n\
             }],
         }];
 
-        let (registry, _) = crate::renderer::PresetRegistry::compile_from_config(&renderers);
+        let (registry, _) = crate::renderer::PresetRegistry::compile_from_config(&renderers, None);
         let mut source_renderer_map = HashMap::new();
         source_renderer_map.insert("test-source".to_string(), vec!["my-preset".to_string()]);
 

--- a/src/renderer/segment.rs
+++ b/src/renderer/segment.rs
@@ -1,4 +1,5 @@
-use ratatui::style::{Modifier, Style};
+use crate::theme::Palette;
+use ratatui::style::{Color, Modifier, Style};
 
 /// The IR unit — text content + style metadata.
 pub struct StyledSegment {
@@ -33,6 +34,7 @@ pub enum SegmentColor {
     Cyan,
     White,
     Gray,
+    Palette(String),
 }
 
 /// Maps severity level strings to appropriate styles. Case-insensitive.
@@ -59,13 +61,16 @@ pub fn resolve_status_code_style(value: &str) -> SegmentStyle {
 }
 
 /// Converts `SegmentStyle` → ratatui `Style`.
-pub fn to_ratatui_style(style: &SegmentStyle) -> Style {
+///
+/// When a palette is provided, fixed color variants (Red, Green, etc.) resolve
+/// through the palette. `Palette(name)` resolves via `palette.get_color(name)`.
+pub fn to_ratatui_style(style: &SegmentStyle, palette: Option<&Palette>) -> Style {
     match style {
         SegmentStyle::Default => Style::default(),
         SegmentStyle::Dim => Style::default().add_modifier(Modifier::DIM),
         SegmentStyle::Bold => Style::default().add_modifier(Modifier::BOLD),
         SegmentStyle::Italic => Style::default().add_modifier(Modifier::ITALIC),
-        SegmentStyle::Fg(color) => Style::default().fg(segment_color_to_ratatui(color)),
+        SegmentStyle::Fg(color) => Style::default().fg(segment_color_to_ratatui(color, palette)),
         SegmentStyle::Compound {
             dim,
             bold,
@@ -83,7 +88,7 @@ pub fn to_ratatui_style(style: &SegmentStyle) -> Style {
                 style = style.add_modifier(Modifier::ITALIC);
             }
             if let Some(color) = fg {
-                style = style.fg(segment_color_to_ratatui(color));
+                style = style.fg(segment_color_to_ratatui(color, palette));
             }
             style
         }
@@ -99,16 +104,126 @@ pub fn segments_to_plain_text(segments: &[StyledSegment]) -> String {
     out
 }
 
-fn segment_color_to_ratatui(color: &SegmentColor) -> ratatui::style::Color {
+fn segment_color_to_ratatui(color: &SegmentColor, palette: Option<&Palette>) -> Color {
     match color {
-        SegmentColor::Red => ratatui::style::Color::Red,
-        SegmentColor::Green => ratatui::style::Color::Green,
-        SegmentColor::Yellow => ratatui::style::Color::Yellow,
-        SegmentColor::Blue => ratatui::style::Color::Blue,
-        SegmentColor::Magenta => ratatui::style::Color::Magenta,
-        SegmentColor::Cyan => ratatui::style::Color::Cyan,
-        SegmentColor::White => ratatui::style::Color::White,
-        SegmentColor::Gray => ratatui::style::Color::Gray,
+        SegmentColor::Red => palette
+            .and_then(|p| p.get_color("red"))
+            .unwrap_or(Color::Red),
+        SegmentColor::Green => palette
+            .and_then(|p| p.get_color("green"))
+            .unwrap_or(Color::Green),
+        SegmentColor::Yellow => palette
+            .and_then(|p| p.get_color("yellow"))
+            .unwrap_or(Color::Yellow),
+        SegmentColor::Blue => palette
+            .and_then(|p| p.get_color("blue"))
+            .unwrap_or(Color::Blue),
+        SegmentColor::Magenta => palette
+            .and_then(|p| p.get_color("magenta"))
+            .unwrap_or(Color::Magenta),
+        SegmentColor::Cyan => palette
+            .and_then(|p| p.get_color("cyan"))
+            .unwrap_or(Color::Cyan),
+        SegmentColor::White => palette
+            .and_then(|p| p.get_color("white"))
+            .unwrap_or(Color::White),
+        SegmentColor::Gray => palette
+            .and_then(|p| p.get_color("bright_black"))
+            .unwrap_or(Color::Gray),
+        SegmentColor::Palette(name) => palette
+            .and_then(|p| p.get_color(name))
+            .unwrap_or(Color::Reset),
+    }
+}
+
+/// Convert styled segments to a string with ANSI escape codes.
+pub fn segments_to_ansi(segments: &[StyledSegment], palette: Option<&Palette>) -> String {
+    let mut out = String::new();
+    for seg in segments {
+        if matches!(seg.style, SegmentStyle::Default) {
+            out.push_str(&seg.text);
+        } else {
+            out.push_str("\x1b[");
+            out.push_str(&style_to_ansi(&seg.style, palette));
+            out.push('m');
+            out.push_str(&seg.text);
+            out.push_str("\x1b[0m");
+        }
+    }
+    out
+}
+
+fn style_to_ansi(style: &SegmentStyle, palette: Option<&Palette>) -> String {
+    match style {
+        SegmentStyle::Default => String::new(),
+        SegmentStyle::Dim => "2".to_string(),
+        SegmentStyle::Bold => "1".to_string(),
+        SegmentStyle::Italic => "3".to_string(),
+        SegmentStyle::Fg(color) => segment_color_to_ansi(color, palette),
+        SegmentStyle::Compound {
+            dim,
+            bold,
+            italic,
+            fg,
+        } => {
+            let mut codes = Vec::new();
+            if *dim {
+                codes.push("2".to_string());
+            }
+            if *bold {
+                codes.push("1".to_string());
+            }
+            if *italic {
+                codes.push("3".to_string());
+            }
+            if let Some(color) = fg {
+                codes.push(segment_color_to_ansi(color, palette));
+            }
+            codes.join(";")
+        }
+    }
+}
+
+fn segment_color_to_ansi(color: &SegmentColor, palette: Option<&Palette>) -> String {
+    match color {
+        SegmentColor::Red => "31".to_string(),
+        SegmentColor::Green => "32".to_string(),
+        SegmentColor::Yellow => "33".to_string(),
+        SegmentColor::Blue => "34".to_string(),
+        SegmentColor::Magenta => "35".to_string(),
+        SegmentColor::Cyan => "36".to_string(),
+        SegmentColor::White => "37".to_string(),
+        SegmentColor::Gray => "90".to_string(),
+        SegmentColor::Palette(name) => {
+            if let Some(color) = palette.and_then(|p| p.get_color(name)) {
+                ratatui_color_to_ansi(color)
+            } else {
+                String::new()
+            }
+        }
+    }
+}
+
+fn ratatui_color_to_ansi(color: Color) -> String {
+    match color {
+        Color::Black => "30".to_string(),
+        Color::Red => "31".to_string(),
+        Color::Green => "32".to_string(),
+        Color::Yellow => "33".to_string(),
+        Color::Blue => "34".to_string(),
+        Color::Magenta => "35".to_string(),
+        Color::Cyan => "36".to_string(),
+        Color::White => "37".to_string(),
+        Color::Gray => "90".to_string(),
+        Color::DarkGray => "90".to_string(),
+        Color::LightRed => "91".to_string(),
+        Color::LightGreen => "92".to_string(),
+        Color::LightYellow => "93".to_string(),
+        Color::LightBlue => "94".to_string(),
+        Color::LightMagenta => "95".to_string(),
+        Color::LightCyan => "96".to_string(),
+        Color::Rgb(r, g, b) => format!("38;2;{};{};{}", r, g, b),
+        _ => String::new(),
     }
 }
 
@@ -158,24 +273,27 @@ mod tests {
 
     #[test]
     fn test_to_ratatui_style_dim() {
-        let style = to_ratatui_style(&SegmentStyle::Dim);
+        let style = to_ratatui_style(&SegmentStyle::Dim, None);
         assert!(style.add_modifier.contains(Modifier::DIM));
     }
 
     #[test]
     fn test_to_ratatui_style_bold() {
-        let style = to_ratatui_style(&SegmentStyle::Bold);
+        let style = to_ratatui_style(&SegmentStyle::Bold, None);
         assert!(style.add_modifier.contains(Modifier::BOLD));
     }
 
     #[test]
     fn test_to_ratatui_style_compound() {
-        let style = to_ratatui_style(&SegmentStyle::Compound {
-            dim: true,
-            bold: true,
-            italic: false,
-            fg: Some(SegmentColor::Cyan),
-        });
+        let style = to_ratatui_style(
+            &SegmentStyle::Compound {
+                dim: true,
+                bold: true,
+                italic: false,
+                fg: Some(SegmentColor::Cyan),
+            },
+            None,
+        );
         assert!(style.add_modifier.contains(Modifier::DIM));
         assert!(style.add_modifier.contains(Modifier::BOLD));
         assert!(!style.add_modifier.contains(Modifier::ITALIC));
@@ -184,12 +302,15 @@ mod tests {
 
     #[test]
     fn test_to_ratatui_style_compound_no_fg() {
-        let style = to_ratatui_style(&SegmentStyle::Compound {
-            dim: false,
-            bold: true,
-            italic: false,
-            fg: None,
-        });
+        let style = to_ratatui_style(
+            &SegmentStyle::Compound {
+                dim: false,
+                bold: true,
+                italic: false,
+                fg: None,
+            },
+            None,
+        );
         assert!(style.add_modifier.contains(Modifier::BOLD));
         assert!(style.fg.is_none());
     }
@@ -216,5 +337,108 @@ mod tests {
     #[test]
     fn test_segments_to_plain_text_empty() {
         assert_eq!(segments_to_plain_text(&[]), "");
+    }
+
+    #[test]
+    fn test_segments_to_ansi_basic() {
+        let segments = vec![
+            StyledSegment {
+                text: "ERROR".to_string(),
+                style: SegmentStyle::Fg(SegmentColor::Red),
+            },
+            StyledSegment {
+                text: " msg".to_string(),
+                style: SegmentStyle::Default,
+            },
+        ];
+        let ansi = segments_to_ansi(&segments, None);
+        assert_eq!(ansi, "\x1b[31mERROR\x1b[0m msg");
+    }
+
+    #[test]
+    fn test_segments_to_ansi_dim() {
+        let segments = vec![StyledSegment {
+            text: "dim text".to_string(),
+            style: SegmentStyle::Dim,
+        }];
+        let ansi = segments_to_ansi(&segments, None);
+        assert!(ansi.contains("\x1b[2m"));
+    }
+
+    #[test]
+    fn test_segments_to_ansi_compound() {
+        let segments = vec![StyledSegment {
+            text: "bold cyan".to_string(),
+            style: SegmentStyle::Compound {
+                dim: false,
+                bold: true,
+                italic: false,
+                fg: Some(SegmentColor::Cyan),
+            },
+        }];
+        let ansi = segments_to_ansi(&segments, None);
+        assert!(ansi.contains("\x1b[1;36m"));
+    }
+
+    #[test]
+    fn test_segments_to_ansi_empty() {
+        assert_eq!(segments_to_ansi(&[], None), "");
+    }
+
+    #[test]
+    fn test_segments_to_ansi_palette_with_palette() {
+        let palette = Palette::dark();
+        let segments = vec![StyledSegment {
+            text: "colored".to_string(),
+            style: SegmentStyle::Fg(SegmentColor::Palette("red".to_string())),
+        }];
+        let ansi = segments_to_ansi(&segments, Some(&palette));
+        // dark palette red is Color::Red → ANSI code 31
+        assert!(ansi.contains("\x1b[31m"));
+    }
+
+    #[test]
+    fn test_segments_to_ansi_palette_without_palette() {
+        let segments = vec![StyledSegment {
+            text: "colored".to_string(),
+            style: SegmentStyle::Fg(SegmentColor::Palette("red".to_string())),
+        }];
+        let ansi = segments_to_ansi(&segments, None);
+        // No palette → empty color code, but still has escape sequence wrapper
+        assert!(ansi.contains("\x1b[m"));
+    }
+
+    #[test]
+    fn test_segment_color_to_ratatui_with_palette() {
+        let mut palette = Palette::dark();
+        palette.red = Color::Rgb(255, 0, 0);
+        let color = segment_color_to_ratatui(&SegmentColor::Red, Some(&palette));
+        assert_eq!(color, Color::Rgb(255, 0, 0));
+    }
+
+    #[test]
+    fn test_segment_color_to_ratatui_without_palette() {
+        let color = segment_color_to_ratatui(&SegmentColor::Red, None);
+        assert_eq!(color, Color::Red);
+    }
+
+    #[test]
+    fn test_segment_color_palette_variant_ratatui() {
+        let palette = Palette::dark();
+        let color = segment_color_to_ratatui(
+            &SegmentColor::Palette("foreground".to_string()),
+            Some(&palette),
+        );
+        assert_eq!(color, palette.foreground);
+    }
+
+    #[test]
+    fn test_segment_color_palette_unknown_ratatui() {
+        let palette = Palette::dark();
+        let color = segment_color_to_ratatui(
+            &SegmentColor::Palette("nonexistent".to_string()),
+            Some(&palette),
+        );
+        assert_eq!(color, Color::Reset);
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -133,6 +133,32 @@ impl Palette {
         }
     }
 
+    /// Look up a palette color by name. Returns `None` for unknown names.
+    pub fn get_color(&self, name: &str) -> Option<Color> {
+        match name {
+            "black" => Some(self.black),
+            "red" => Some(self.red),
+            "green" => Some(self.green),
+            "yellow" => Some(self.yellow),
+            "blue" => Some(self.blue),
+            "magenta" => Some(self.magenta),
+            "cyan" => Some(self.cyan),
+            "white" => Some(self.white),
+            "bright_black" => Some(self.bright_black),
+            "bright_red" => Some(self.bright_red),
+            "bright_green" => Some(self.bright_green),
+            "bright_yellow" => Some(self.bright_yellow),
+            "bright_blue" => Some(self.bright_blue),
+            "bright_magenta" => Some(self.bright_magenta),
+            "bright_cyan" => Some(self.bright_cyan),
+            "bright_white" => Some(self.bright_white),
+            "foreground" => Some(self.foreground),
+            "background" => Some(self.background),
+            "selection" => Some(self.selection),
+            _ => None,
+        }
+    }
+
     pub fn light() -> Self {
         Self {
             black: Color::Black,
@@ -471,5 +497,51 @@ mod tests {
                 Color::LightGreen,
             ]
         );
+    }
+
+    #[test]
+    fn test_palette_get_color_standard() {
+        let palette = Palette::dark();
+        assert_eq!(palette.get_color("red"), Some(palette.red));
+        assert_eq!(palette.get_color("green"), Some(palette.green));
+        assert_eq!(palette.get_color("yellow"), Some(palette.yellow));
+        assert_eq!(palette.get_color("blue"), Some(palette.blue));
+        assert_eq!(palette.get_color("magenta"), Some(palette.magenta));
+        assert_eq!(palette.get_color("cyan"), Some(palette.cyan));
+        assert_eq!(palette.get_color("white"), Some(palette.white));
+        assert_eq!(palette.get_color("black"), Some(palette.black));
+        assert_eq!(palette.get_color("bright_red"), Some(palette.bright_red));
+        assert_eq!(
+            palette.get_color("bright_green"),
+            Some(palette.bright_green)
+        );
+        assert_eq!(
+            palette.get_color("bright_yellow"),
+            Some(palette.bright_yellow)
+        );
+        assert_eq!(palette.get_color("bright_blue"), Some(palette.bright_blue));
+        assert_eq!(
+            palette.get_color("bright_magenta"),
+            Some(palette.bright_magenta)
+        );
+        assert_eq!(palette.get_color("bright_cyan"), Some(palette.bright_cyan));
+        assert_eq!(
+            palette.get_color("bright_white"),
+            Some(palette.bright_white)
+        );
+        assert_eq!(
+            palette.get_color("bright_black"),
+            Some(palette.bright_black)
+        );
+        assert_eq!(palette.get_color("foreground"), Some(palette.foreground));
+        assert_eq!(palette.get_color("background"), Some(palette.background));
+        assert_eq!(palette.get_color("selection"), Some(palette.selection));
+    }
+
+    #[test]
+    fn test_palette_get_color_unknown() {
+        let palette = Palette::dark();
+        assert_eq!(palette.get_color("nonexistent"), None);
+        assert_eq!(palette.get_color(""), None);
     }
 }

--- a/src/tui/log_view.rs
+++ b/src/tui/log_view.rs
@@ -70,6 +70,7 @@ pub(super) fn render_log_view(f: &mut Frame, area: Rect, app: &mut App) -> Resul
     let preset_registry = app.preset_registry.clone();
 
     let ui = &app.theme.ui;
+    let palette = &app.theme.palette;
     let tab = if let Some(cat) = app.active_combined {
         app.combined_tabs[cat as usize]
             .as_mut()
@@ -307,9 +308,10 @@ pub(super) fn render_log_view(f: &mut Frame, area: Rect, app: &mut App) -> Resul
                 if let Some(segments) = preset_segments {
                     // Use preset-rendered spans
                     for seg in &segments {
-                        final_line
-                            .spans
-                            .push(Span::styled(seg.text.clone(), to_ratatui_style(&seg.style)));
+                        final_line.spans.push(Span::styled(
+                            seg.text.clone(),
+                            to_ratatui_style(&seg.style, Some(palette)),
+                        ));
                     }
                 } else {
                     // Fallback to ANSI parsing


### PR DESCRIPTION
## Summary
- Capture mode (`lazytail -n`) now applies rendering presets to format stdout with ANSI colors, with `--raw` flag to bypass
- Segment colors resolve through the theme palette at render time; new `palette.X` syntax for explicit palette references in YAML presets
- External preset files can be loaded from `.lazytail/renderers/`, `renderers/`, and `~/.config/lazytail/renderers/`

## Changes
- `src/capture.rs` — Accept preset registry, renderer names, palette, and raw flag; render lines through presets before writing to stdout
- `src/main.rs` — Move preset compilation before capture dispatch; pass rendering context to `run_capture_mode`; add `--raw` CLI flag; pass project root to `compile_from_config`
- `src/renderer/mod.rs` — Add `render_line` and `render_line_auto` methods to `PresetRegistry`; accept `project_root` in `compile_from_config` for external preset discovery
- `src/renderer/preset.rs` — Load external `.yaml` presets from project and global renderer directories
- `src/renderer/segment.rs` — Add `segments_to_ansi` for ANSI string output; `SegmentColor::Palette` variant resolves through theme; palette-aware color resolution
- `src/theme/mod.rs` — Add `Palette::get_color()` lookup by name; `Palette::dark()` and `Palette::light()` constructors
- `src/mcp/tools.rs` — Pass `None` for new optional palette parameter in render calls
- `src/tui/log_view.rs` — Pass palette reference to segment color resolution

## Testing
- New unit test `test_capture_rendering_integration` verifies end-to-end rendering through JSON preset with ANSI output
- Existing test suite passes (`cargo test`, `cargo clippy`, `cargo fmt --check`)