### PR TITLE
docs: update project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,24 +133,30 @@ kubectl logs -f my-pod | lazytail -n "MyApp"
 
 ## Features
 
-- **Multi-tab support** - Open multiple log files in tabs with side panel navigation
-- **Stdin support** - Pipe logs directly with auto-detection (`cmd | lazytail`)
-- **Lazy file reading** - Efficiently handles large log files using indexed line positions
-- **TUI interface** - Clean terminal UI with ratatui
-- **Live filtering** - See results instantly as you type with regex or plain text
-- **Filter history** - Navigate and reuse previous filter patterns
-- **Background filtering** - Non-blocking filtering keeps UI responsive
-- **File watching** - Auto-reload when log file is modified (using inotify on Linux)
-- **Follow mode** - Auto-scroll to show latest logs as they arrive (like `tail -f`)
-- **ANSI color support** - Parses and renders ANSI escape codes in full color
-- **Line expansion** - Expand long lines for better readability
-- **Memory efficient** - Viewport-based rendering keeps RAM usage low
-- **Vim-style navigation** - Familiar keybindings for efficient navigation
-- **Severity detection** - Automatic log level coloring (ERROR/WARN/INFO/DEBUG) with severity histogram
-- **Columnar index** - Per-line metadata index built during capture for instant severity stats and accelerated filtering
-- **Config system** - Project-scoped `lazytail.yaml` config with source definitions
-- **Query language** - Structured field filtering (`json | level == "error"`)
-- **Web UI mode** - Browser interface with virtualized source/log lists (`lazytail web`)
+- **Multi-tab support** — Open multiple log files in tabs with side panel navigation
+- **Stdin support** — Pipe logs directly with auto-detection (`cmd | lazytail`)
+- **Lazy file reading** — Efficiently handles large log files using indexed line positions
+- **TUI interface** — Clean terminal UI with ratatui, mouse support
+- **Live filtering** — See results instantly as you type with regex or plain text
+- **Filter history** — Navigate and reuse previous filter patterns
+- **Background filtering** — Non-blocking filtering keeps UI responsive
+- **File watching** — Auto-reload when log file is modified (using inotify on Linux)
+- **Follow mode** — Auto-scroll to show latest logs as they arrive (like `tail -f`)
+- **ANSI color support** — Parses and renders ANSI escape codes in full color
+- **Line expansion** — Expand long lines for better readability
+- **Copy to clipboard** — Copy current line with `y`
+- **Memory efficient** — Viewport-based rendering keeps RAM usage low
+- **Vim-style navigation** — Familiar keybindings for efficient navigation
+- **Severity detection** — Automatic log level coloring (ERROR/WARN/INFO/DEBUG) with severity histogram
+- **Columnar index** — Per-line metadata index built during capture for instant severity stats and accelerated filtering
+- **Config system** — Project-scoped `lazytail.yaml` config with source definitions
+- **Query language** — Structured field filtering (`json | level == "error"`) with aggregation (`count by (field)`)
+- **Rendering presets** — Configurable structured log formatting via YAML for custom log layouts
+- **Theme support** — Color schemes with import from Windows Terminal, Alacritty, Ghostty, iTerm2
+- **Session persistence** — Remembers last-opened source per project
+- **Combined view** — Merge multiple sources chronologically using index timestamps
+- **Benchmark tool** — Filter performance benchmarking (`lazytail bench`)
+- **Web UI mode** — Browser interface with virtualized source/log lists (`lazytail web`)
 
 Press `?` in the app to see all keyboard shortcuts.
 
@@ -197,15 +203,16 @@ lazytail [OPTIONS] [FILE]... [COMMAND]
 Commands:
   init              Initialize a new lazytail.yaml config file
   web               Start browser-based web UI
-  config validate   Validate the config file
-  config show       Show effective configuration
-  update            Check for and install updates (GitHub release builds only)
+  bench             Benchmark filter performance
+  config            Config file commands (validate, show)
+  theme             Theme management commands (import, list)
+  help              Print help for a command
 
 Options:
   -n, --name <NAME>        Capture stdin to ~/.config/lazytail/data/<NAME>.log
+      --raw                Output raw lines without rendering (only with -n)
       --no-watch           Disable file watching
       --mcp                Run as MCP server for AI assistants
-      --no-update-check    Disable background update check on startup
   -v, --verbose            Verbose output (show config discovery paths)
   -h, --help               Print help
   -V, --version            Print version
@@ -255,6 +262,58 @@ lazytail  # Shows tabs: [API] [Worker] with live status
 ```
 
 Captured sources show active (●) or ended (○) status in the UI.
+
+Use `--raw` to output raw lines without rendering presets:
+
+```bash
+kubectl logs -f api-pod | lazytail -n "API" --raw
+```
+
+### Themes
+
+LazyTail supports color schemes for customizing the UI appearance.
+
+```bash
+# List available themes
+lazytail theme list
+
+# Import from Windows Terminal, Alacritty, Ghostty, or iTerm2
+lazytail theme import my-scheme.json
+lazytail theme import --name "My Theme" alacritty.toml
+```
+
+Set the active theme in `lazytail.yaml`:
+
+```yaml
+theme: my-scheme
+```
+
+### Benchmarking
+
+Measure filter performance on your log files:
+
+```bash
+# Benchmark a plain text filter
+lazytail bench "error" app.log
+
+# Benchmark regex filter
+lazytail bench --regex "level=(error|warn)" app.log
+
+# Benchmark structured query
+lazytail bench --query "json | level == \"error\"" app.log
+
+# Case-sensitive matching
+lazytail bench --case-sensitive "Error" app.log
+
+# Compare indexed vs non-indexed performance
+lazytail bench --compare "error" app.log
+
+# Custom number of trials (default: 5)
+lazytail bench --trials 10 "error" app.log
+
+# Output JSON results
+lazytail bench --json "error" app.log
+```
 
 ### Use Cases
 

--- a/docs/HEXAGONAL_ANALYSIS.md
+++ b/docs/HEXAGONAL_ANALYSIS.md
@@ -2,7 +2,9 @@
 
 ## The Problem
 
-Three interfaces (TUI, MCP, upcoming Web UI) each independently wire together readers, indexes, and filters. Adding an index feature means touching `FilterOrchestrator` (TUI), `mcp/tools.rs` (MCP), and soon a third place (Web UI). The core domain operations — "open a log source", "search with index acceleration", "get line content" — are duplicated across adapters rather than expressed once.
+Three interfaces (TUI, MCP, Web UI) each independently wire together readers, indexes, and filters. Adding an index feature means touching `FilterOrchestrator` (TUI), `mcp/tools.rs` (MCP), and the Web UI. The core domain operations — "open a log source", "search with index acceleration", "get line content" — were duplicated across adapters rather than expressed once.
+
+> **Update:** Phases 1–2 from the recommended approach below have been implemented. `LogSource` (in `src/log_source.rs`) and `SearchEngine` (in `src/filter/search_engine.rs`) now exist. `FilterOrchestrator` delegates search dispatch to `SearchEngine`, and all three adapters share the `LogSource` domain struct via `TabState.source`. The coupling map below reflects the state before these changes.
 
 ## Current Coupling Map
 

--- a/docs/INDEX_STATUS.md
+++ b/docs/INDEX_STATUS.md
@@ -14,9 +14,9 @@
 - [x] Wire LineIndexer into capture.rs (capture mode -n flag)
 - [x] Wire IndexBuilder into source discovery (build index for existing files)
 - [ ] Add index-aware LogReader (read lines via offset column instead of sparse index)
-- [ ] TUI: severity-based line coloring from flags column
-- [ ] TUI: severity histogram from checkpoint counts
-- [ ] MCP: expose index stats via tools
+- [x] TUI: severity-based line coloring from flags column
+- [x] TUI: severity histogram from checkpoint counts
+- [x] MCP: expose index stats via tools
 - [ ] Config: format hints in lazytail.yaml (json/logfmt/plain)
 - [ ] Auto-detection: sample first 20 lines, infer format
 - [ ] Incremental rebuild: detect log file truncation/rotation

--- a/docs/adr/015-columnar-index-system.md
+++ b/docs/adr/015-columnar-index-system.md
@@ -1,0 +1,50 @@
+# ADR-015: Columnar Index System
+
+## Status
+
+Accepted
+
+## Context
+
+LazyTail needed per-line metadata (severity level, timestamps, byte offsets) for features like severity-based coloring, severity histograms, and accelerated filtering. The index had to support:
+
+- Concurrent reading while a capture process writes new lines
+- Incremental updates (append-only during capture)
+- Selective column loading (only read flags when filtering by severity)
+- Low memory overhead for large files (millions of lines)
+
+Alternatives considered:
+- **SQLite**: Too heavy for a CLI tool; adds a runtime dependency and write-ahead log complexity. Overkill for append-only integer columns.
+- **Single binary file**: All columns interleaved per row. Simpler, but forces reading all columns even when only flags are needed. Poor cache locality for column-scan queries.
+- **Parquet/Arrow**: Designed for analytics workloads with compression and encoding schemes. Too complex for our fixed-width integer columns and append-only write pattern.
+
+## Decision
+
+Use a **per-column binary file** format where each column is stored as a separate append-only file of fixed-width little-endian values:
+
+- `flags` (u32): severity level, format flags, line classification bits
+- `offsets` (u64): byte offset of each line in the log file
+- `lengths` (u32): byte length of each line
+- `time` (u64): extracted timestamp per line
+- `checkpoints`: periodic severity count snapshots for histograms
+
+A 64-byte `IndexMeta` header tracks which columns are present (via `ColumnBit` flags) and the entry count.
+
+`IndexReader` copies column data into owned `Vec<T>` at open time rather than keeping mmap handles alive. This makes readers immune to SIGBUS when a concurrent writer truncates and re-creates a column file.
+
+`IndexWriteLock` (`lock.rs`) uses `flock(2)` to prevent concurrent index builds. The lock is automatically released if the holding process crashes.
+
+## Consequences
+
+**Benefits:**
+- Selective column loading: filtering by severity only reads the `flags` file
+- Append-only writes: capture mode appends entries without rebuilding
+- Type safety: `ColumnReader<T>` and `ColumnWriter<T>` enforce fixed-size encoding via the `ColumnElement` trait
+- Reader isolation: copying data at open time eliminates SIGBUS risk from concurrent writers
+- Simple format: no compression, no encoding — just fixed-width integers. Easy to debug with `hexdump`
+
+**Trade-offs:**
+- Multiple files per index directory (one per column) increases filesystem overhead
+- Copying data at open time uses more memory than mmap (but bounded by file size)
+- No built-in compression — index size is proportional to line count × column width
+- Lock file mechanism depends on `flock(2)` semantics (Unix-only)

--- a/docs/adr/016-renderer-preset-architecture.md
+++ b/docs/adr/016-renderer-preset-architecture.md
@@ -1,0 +1,49 @@
+# ADR-016: Renderer Preset Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+Log files come in many structured formats (JSON, logfmt, custom patterns). Users need to see parsed, formatted output rather than raw text. The formatting system needed to support:
+
+- Multiple log formats within the same project
+- User-customizable layouts without code changes
+- Auto-detection of format per line
+- Reasonable defaults out of the box
+
+Alternatives considered:
+- **Lua scripting**: Maximum flexibility, but adds a scripting runtime dependency and a learning curve. Overkill for layout definitions that are mostly "extract field X, show it in color Y with width Z."
+- **Regex-only**: Simple but can't express field extraction from JSON or logfmt. Would require regex groups for every field, making definitions fragile.
+- **Hardcoded formatters**: Fast to implement initially, but every new format requires a code change and rebuild.
+
+## Decision
+
+Use **declarative YAML preset definitions** compiled into `CompiledPreset` at startup. Each preset specifies:
+
+- **Parser**: how to extract fields (`json`, `logfmt`, or `regex` with named capture groups)
+- **Detect rules**: patterns to auto-match presets to log lines (filename globs, string/regex content matches)
+- **Layout entries**: ordered list of field extractions → styled segments (color, width, alignment, conditional styling)
+
+Presets follow a three-tier priority system:
+1. **Inline config presets** (in `lazytail.yaml` `renderers:` section) — highest priority
+2. **External file presets** (from `.lazytail/renderers/` or `renderers/` directories)
+3. **Builtin presets** (JSON and logfmt defaults compiled into the binary) — lowest priority
+
+Duplicate names use the highest-priority version, allowing users to override builtins.
+
+The `PresetRegistry` holds all compiled presets. Each source can have explicit renderer names assigned via config, or presets are auto-detected per line using detect rules.
+
+## Consequences
+
+**Benefits:**
+- Users customize log formatting via YAML without touching Rust code
+- Auto-detection selects the right preset per line, supporting mixed-format logs
+- Builtin presets provide immediate value for JSON and logfmt without configuration
+- Priority system lets users override any builtin behavior
+
+**Trade-offs:**
+- YAML compilation at startup adds a small delay (negligible for typical preset counts)
+- Declarative definitions can't express arbitrary formatting logic (no conditionals beyond `style_when`)
+- Auto-detection runs per line, adding overhead for rendered lines (mitigated by caching)

--- a/docs/adr/017-theme-system.md
+++ b/docs/adr/017-theme-system.md
@@ -1,0 +1,43 @@
+# ADR-017: Theme System
+
+## Status
+
+Accepted
+
+## Context
+
+LazyTail's UI colors were hardcoded, making it difficult to adapt to different terminal color schemes and user preferences. Users on light-background terminals had poor contrast, and there was no way to match the tool's appearance to their terminal emulator theme.
+
+The theme system needed to:
+- Support both light and dark terminal backgrounds
+- Allow users to reuse color schemes from their terminal emulator
+- Provide sensible defaults without configuration
+- Support partial overrides (change one color without redefining everything)
+
+## Decision
+
+Implement a **two-level color system** with YAML-based themes:
+
+1. **Palette layer**: 16 ANSI-style colors plus foreground, background, and selection colors. This maps to the terminal emulator's color model.
+2. **UI colors layer**: Semantic colors derived from the palette (e.g., `severity_error`, `filter_query`, `selection_bg`). Automatically computed from palette via `derive_ui_colors()`.
+
+Theme resolution follows a priority chain: project theme (from `lazytail.yaml`) > global theme (from `~/.config/lazytail/themes/`) > built-in default.
+
+Light/dark detection: `Palette.is_background_light()` checks background luminance and adjusts derived UI colors accordingly.
+
+**Multi-format import** via `lazytail theme import`: converts color schemes from Windows Terminal (.json), Alacritty (.toml), Ghostty (.conf), and iTerm2 (.itermcolors) into LazyTail's YAML format. This lets users match their log viewer to their terminal without manual color copying.
+
+Override composition: palette overrides trigger re-derivation of UI colors, then explicit UI overrides are applied on top — enabling both automatic adaptation and manual fine-tuning.
+
+## Consequences
+
+**Benefits:**
+- Automatic light/dark adaptation without user configuration
+- One-command import from popular terminal emulators
+- Partial overrides: change one palette color and all dependent UI colors update automatically
+- YAML themes are human-readable and shareable
+
+**Trade-offs:**
+- Two-level indirection (palette → UI colors) adds complexity to the color resolution path
+- Import from external formats may lose nuance (e.g., iTerm2 has more than 16 colors)
+- Theme files must be discovered from multiple directories, adding startup I/O

--- a/docs/adr/018-aggregation-pipeline.md
+++ b/docs/adr/018-aggregation-pipeline.md
@@ -1,0 +1,45 @@
+# ADR-018: Aggregation Pipeline
+
+## Status
+
+Accepted
+
+## Context
+
+Users analyzing structured logs frequently need to answer questions like "how many errors per service?" or "which status codes appear most?" The existing filter pipeline produced a flat list of matching lines, requiring users to mentally group results.
+
+The aggregation system needed to:
+- Integrate with the existing query language (`json | level == "error"`)
+- Reuse existing field extraction (JSON and logfmt parsers)
+- Support drill-down from aggregated groups back to individual lines
+- Work within the TUI's event-driven architecture
+
+## Decision
+
+Add **post-filter aggregation** via `count by (field1, field2)` syntax appended to query expressions, with optional `top N` limiting.
+
+The aggregation pipeline:
+1. User enters a query with aggregation clause: `json | level == "error" | count by (service) top 10`
+2. The filter pipeline runs as normal, producing `matching_indices`
+3. When filtering completes, `AggregationResult::compute()` processes the matched lines:
+   - Extracts group-by field values using the query's parser (JSON/logfmt)
+   - Accumulates counts and line indices per group in a HashMap
+   - Sorts groups by count descending
+   - Applies optional `top N` limit
+4. The view switches to `ViewMode::Aggregation`, rendering groups as a navigable list
+5. Selecting a group triggers drill-down: switches to a filtered view showing only that group's lines
+
+The `Aggregation` struct is part of the shared `FilterQuery` AST in `query.rs`, so both TUI and MCP can parse and use it.
+
+## Consequences
+
+**Benefits:**
+- Natural extension of the query language — no new UI mode to learn
+- Reuses existing parser infrastructure (JSON/logfmt field extraction)
+- Drill-down preserves context: users can inspect individual lines behind a count
+- Shared AST means MCP gets aggregation support automatically
+
+**Trade-offs:**
+- In-memory grouping: all matched lines must be read to extract field values. For very large result sets, this can be slow.
+- Only `count by` is supported — no `sum`, `avg`, or other aggregation types
+- Drill-down saves and restores aggregation state, adding complexity to `FilterConfig`

--- a/docs/adr/019-combined-merged-source-view.md
+++ b/docs/adr/019-combined-merged-source-view.md
@@ -1,0 +1,44 @@
+# ADR-019: Combined / Merged Source View
+
+## Status
+
+Accepted
+
+## Context
+
+Users working with microservices often need to correlate logs across multiple services. Opening each service in a separate tab requires manual context-switching. A unified chronological view of all sources would let users see the full timeline of events across services.
+
+The merge mechanism needed to:
+- Interleave lines from multiple sources by timestamp
+- Work transparently with existing filter, viewport, and rendering infrastructure
+- Handle sources with and without timestamp indexes
+- Avoid deadlocks when sharing readers with individual source tabs
+
+## Decision
+
+Implement `CombinedReader` as a `LogReader` trait implementation that merges lines from multiple sources in timestamp order.
+
+**Merge strategy:**
+- Collect all lines from all sources as `MergedLine { source_id, file_line, timestamp }`
+- Extract timestamps from the columnar index when available (`IndexReader::get_timestamp`)
+- Sources without indexes default to timestamp 0 (sorted to the beginning)
+- Stable sort by timestamp preserves source order for lines with equal timestamps
+
+**LogReader transparency:** Because `CombinedReader` implements `LogReader`, the existing viewport, filter pipeline, and renderer work without special cases. Tabs with `is_combined: true` use a `CombinedReader` instead of a single-file reader.
+
+**Lock ordering:** `CombinedReader` holds `Arc<Mutex<dyn LogReader>>` references shared with individual source tabs. Lock ordering is always outer → inner (combined reader → source reader) to prevent deadlocks.
+
+**Source attribution:** `source_info()` method maps virtual line numbers back to their origin source, enabling source-prefixed rendering and source-specific renderer selection.
+
+## Consequences
+
+**Benefits:**
+- Unified timeline across services without manual correlation
+- Transparent integration: filters, viewport navigation, and line expansion all work on combined views
+- Source attribution preserves context (which service produced each line)
+
+**Trade-offs:**
+- Rebuilding the merged index on source changes (new lines appended) requires re-collecting and re-sorting all lines
+- Sources without indexes lack timestamps and cluster at the beginning of the merged view
+- Shared reader locks may cause brief render stalls if a filter thread holds a source lock
+- Memory grows linearly with total line count across all sources (one `MergedLine` per line)

--- a/docs/adr/020-search-engine-extraction.md
+++ b/docs/adr/020-search-engine-extraction.md
@@ -1,0 +1,39 @@
+# ADR-020: SearchEngine Extraction
+
+## Status
+
+Accepted
+
+## Context
+
+Filter dispatch logic — deciding whether to use SIMD, index bitmaps, byte offset ranges, or reader-based filtering — was duplicated between `FilterOrchestrator` (TUI) and `mcp/tools.rs` (MCP). Adding a new index-acceleration path (e.g., timestamp range filtering) required changes in both places, with the risk of feature gaps between adapters.
+
+The hexagonal architecture analysis (see `docs/HEXAGONAL_ANALYSIS.md`) identified this as the highest-value extraction: centralizing dispatch logic so that index features become single-point changes.
+
+## Decision
+
+Extract the dispatch logic into `SearchEngine` (`src/filter/search_engine.rs`), a stateless struct with two entry points:
+
+- `search_file()`: For file-backed sources. Picks the fastest path based on filter type, available index, query AST, and range:
+  1. Index-accelerated + incremental range → `streaming_filter_range` with bitmap
+  2. Index-accelerated full scan → `streaming_filter_indexed` with bitmap
+  3. Generic full scan → `streaming_filter`
+  4. SIMD fast path (plain text) → bypasses `Filter` trait entirely
+
+- `search_reader()`: For stdin/pipe sources using `FilterEngine` with shared reader mutex
+
+Both return `Receiver<FilterProgress>`, keeping the API uniform across all callers.
+
+`FilterOrchestrator` (TUI/Web) delegates to `SearchEngine` after building the filter and managing `TabState` fields (cancel token, receiver, state transitions). MCP calls `SearchEngine` directly.
+
+## Consequences
+
+**Benefits:**
+- Single point for all dispatch decisions — adding a new acceleration path (e.g., timestamp range) requires changing only `SearchEngine`
+- Both TUI and MCP get the same optimizations automatically
+- Stateless design makes the module easy to test in isolation
+- Clear separation: `FilterOrchestrator` manages state, `SearchEngine` manages dispatch
+
+**Trade-offs:**
+- `FilterOrchestrator` still exists as a thin wrapper for state management — not fully eliminated
+- MCP's synchronous usage pattern collects results from the receiver inline, which works but isn't the most natural API for synchronous callers

--- a/docs/adr/021-web-server-architecture.md
+++ b/docs/adr/021-web-server-architecture.md
@@ -1,0 +1,51 @@
+# ADR-021: Web Server Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+LazyTail needed a browser-based interface for users who prefer GUIs or need to share log views. The web server is a secondary interface — the TUI remains primary. Design constraints:
+
+- Minimal additional dependencies (LazyTail is a CLI tool, not a web framework)
+- Share domain state with the TUI (same `LogSource`, filters, indexes)
+- Single binary deployment (no separate frontend build or static file serving)
+- Sufficient for localhost usage, not a production web service
+
+Alternatives considered:
+- **actix-web / axum**: Full-featured async web frameworks. Would pull in a large dependency tree and require restructuring around async. Overkill for a simple REST API serving one user.
+- **Separate frontend**: React/Vue SPA with a build pipeline. Adds toolchain complexity, CI steps, and a deployment concern. A single embedded HTML file is simpler.
+
+## Decision
+
+Use **tiny_http** for the HTTP server with an **embedded single-page application** (HTML inlined as a string constant).
+
+Architecture:
+- `lazytail web` starts a `tiny_http::Server` on `127.0.0.1:8421` (configurable via `--host` and `--port`)
+- The SPA is served from a single `INDEX_HTML` string constant — no static file directory needed
+- App state is shared via `Arc<Mutex<App>>` between the HTTP handler thread and the main event loop
+- Long-polling for updates: clients poll `/api/events` which blocks until state changes or a 25-second timeout
+
+Key API endpoints:
+- `GET /api/sources` — list sources with severity counts and filter state
+- `GET /api/lines` — paginated line content with per-line severity
+- `POST /api/filter` — trigger filter via `FilterOrchestrator`
+- `POST /api/filter/clear` — cancel and clear filter
+- `POST /api/follow` — toggle follow mode
+
+Request limits prevent abuse: `MAX_LINES_PER_REQUEST` (5,000), `MAX_REQUEST_BODY_SIZE` (1MB), `MAX_PENDING_EVENT_REQUESTS` (256).
+
+## Consequences
+
+**Benefits:**
+- Single binary — no separate frontend build or static files to deploy
+- Minimal dependencies — tiny_http is small and synchronous
+- Shared state — web UI sees exactly the same data as TUI, no duplication
+- Simple deployment — `lazytail web` just works
+
+**Trade-offs:**
+- Single-threaded request handling limits concurrent users (acceptable for localhost)
+- Embedded HTML means frontend changes require a Rust rebuild
+- No WebSocket support — long-polling has higher latency than push-based updates
+- `Arc<Mutex<App>>` creates contention between HTTP handler and event loop under load

--- a/docs/adr/022-session-persistence.md
+++ b/docs/adr/022-session-persistence.md
@@ -1,0 +1,51 @@
+# ADR-022: Session Persistence
+
+## Status
+
+Accepted
+
+## Context
+
+Users working on multi-service projects frequently return to the same log source across sessions. Without session persistence, every launch starts with no source selected, requiring manual navigation to the desired tab.
+
+The session system needed to:
+- Remember which source was last active per project
+- Distinguish between different project contexts
+- Handle missing or corrupted session data gracefully
+- Not interfere with test execution
+
+## Decision
+
+Store per-project session state in a single JSON file at `~/.config/lazytail/session.json`.
+
+**Scope:** The session file maps **project context keys** to **last-active source names**. The context key is the project root path (from `lazytail.yaml` discovery) or `"__global__"` for non-project usage.
+
+**Format:**
+```json
+{
+  "contexts": {
+    "/home/user/project-a": { "last_source": "API" },
+    "/home/user/project-b": { "last_source": "Worker" },
+    "__global__": { "last_source": "syslog" }
+  }
+}
+```
+
+**Bounded storage:** The file caps at 100 context entries (`MAX_CONTEXTS`) to prevent unbounded growth from users switching between many projects.
+
+**Graceful degradation:** All session operations use `Option` chains — if the file is missing, corrupted, or unreadable, the app starts normally without a last-source preference. No error dialogs or warnings.
+
+**Test isolation:** Session I/O functions are conditionally compiled (`#[cfg(not(test))]`) to prevent tests from reading or writing the user's real session file.
+
+## Consequences
+
+**Benefits:**
+- Seamless workflow continuity — open LazyTail and immediately see the source you were last viewing
+- Project-scoped: different projects remember different sources
+- Zero configuration required — works automatically after first use
+- Graceful degradation — corrupted or missing session data is silently ignored
+
+**Trade-offs:**
+- Only stores last-active source, not full session state (open tabs, filter history, scroll position)
+- Single JSON file may have write conflicts if multiple LazyTail instances save simultaneously (unlikely in practice)
+- Conditional compilation for test isolation means test code can't verify session persistence behavior directly

--- a/docs/adr/023-self-update-mechanism.md
+++ b/docs/adr/023-self-update-mechanism.md
@@ -1,0 +1,54 @@
+# ADR-023: Self-Update Mechanism
+
+## Status
+
+Accepted
+
+## Context
+
+LazyTail distributes pre-built binaries via GitHub releases. Users who installed via the install script (rather than a package manager) had no built-in way to check for or install updates. The update mechanism needed to:
+
+- Check for new releases without disrupting the user's workflow
+- Respect users who installed via package managers (pacman, dpkg, brew)
+- Avoid network requests on every launch
+- Be opt-out for users who don't want update checks
+- Not bloat the binary for users who don't need it
+
+## Decision
+
+Implement self-update as a **feature-gated module** (`self-update` feature flag), disabled by default in development builds and enabled in release builds.
+
+**Update check strategy:**
+- Background check on startup: queries the GitHub releases API for the latest version
+- **24-hour cache**: results are cached in `~/.config/lazytail/update-cache.json` to avoid repeated network requests
+- If a newer version is available, a non-intrusive notice is shown
+- Users can disable checks via the `update_check` config field in `lazytail.yaml`
+
+**Update installation (`lazytail update`):**
+- Downloads the appropriate binary for the current OS/architecture from GitHub releases
+- Replaces the running binary with the downloaded one
+- `--check` flag: only check for updates without installing (exit code 0 = up-to-date, 1 = available)
+
+**Package manager detection:**
+- Before offering self-update, checks if the binary was installed via a package manager (pacman, dpkg, brew) by inspecting package databases
+- If a package manager owns the binary, advises the user to update through their package manager instead
+- Falls back to path-based detection if no package manager is found
+
+**Feature gating:**
+- The entire `update/` module and CLI flags (`update` subcommand, `--no-update-check`) are behind `#[cfg(feature = "self-update")]`
+- This keeps the binary small and dependency-free for users who don't need it
+- The `self_update` crate is only compiled when the feature is enabled
+
+## Consequences
+
+**Benefits:**
+- Users get notified of updates without manual checking
+- 24-hour cache prevents excessive API calls
+- Package manager awareness prevents conflicts with system package management
+- Feature gating keeps the default binary lean
+
+**Trade-offs:**
+- Feature-gated code paths increase conditional compilation complexity
+- GitHub API rate limits could affect users behind shared IPs (mitigated by caching)
+- Binary replacement is Unix-specific (not tested on Windows)
+- Config-based opt-out (`update_check` field) requires users to create a config file to disable checks

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,16 @@ This directory contains Architecture Decision Records (ADRs) for LazyTail. Each 
 | [011](011-project-scoped-storage.md) | Project-Scoped vs Global Source Storage | Accepted |
 | [012](012-incremental-filtering.md) | Incremental Filtering on File Growth | Accepted |
 | [013](013-live-filter-preview.md) | Live Filter Preview with Debouncing | Accepted |
-| [014](014-hexagonal-log-source-state.md) | Hexagonal Architecture — LogSourceState Extraction | Accepted |
+| [014](014-hexagonal-log-source-state.md) | Hexagonal Architecture — LogSource Extraction | Accepted |
+| [015](015-columnar-index-system.md) | Columnar Index System | Accepted |
+| [016](016-renderer-preset-architecture.md) | Renderer Preset Architecture | Accepted |
+| [017](017-theme-system.md) | Theme System | Accepted |
+| [018](018-aggregation-pipeline.md) | Aggregation Pipeline | Accepted |
+| [019](019-combined-merged-source-view.md) | Combined / Merged Source View | Accepted |
+| [020](020-search-engine-extraction.md) | SearchEngine Extraction | Accepted |
+| [021](021-web-server-architecture.md) | Web Server Architecture | Accepted |
+| [022](022-session-persistence.md) | Session Persistence | Accepted |
+| [023](023-self-update-mechanism.md) | Self-Update Mechanism | Accepted |
 
 ## Format
 


### PR DESCRIPTION
## Summary
Comprehensive documentation update based on automated audit of codebase vs existing docs.

## Changes

### Modified Files
- **README.md** — Updated feature list, installation instructions, and usage examples to reflect current state
- **CONTRIBUTING.md** — Expanded contributor guide with updated build commands, architecture overview, and conventions
- **docs/ARCHITECTURE.md** — Major rewrite covering new modules (web, MCP, renderer presets, theme system, index, session)
- **docs/HEXAGONAL_ANALYSIS.md** — Minor fixes for accuracy
- **docs/INDEX_STATUS.md** — Updated status to reflect current index implementation
- **docs/adr/README.md** — Updated ADR index with new entries

### New Files
- **docs/adr/015-columnar-index-system.md** — ADR for columnar index architecture
- **docs/adr/016-renderer-preset-architecture.md** — ADR for YAML-based rendering presets
- **docs/adr/017-theme-system.md** — ADR for multi-format theme import system
- **docs/adr/018-aggregation-pipeline.md** — ADR for grouped query aggregation
- **docs/adr/019-combined-merged-source-view.md** — ADR for multi-source chronological merging
- **docs/adr/020-search-engine-extraction.md** — ADR for unified search dispatch
- **docs/adr/021-web-server-architecture.md** — ADR for HTTP server with embedded SPA
- **docs/adr/022-session-persistence.md** — ADR for last-opened source memory
- **docs/adr/023-self-update-mechanism.md** — ADR for self-update feature

## Audit Findings Addressed
- Architecture docs were missing coverage for 8+ modules added since last update (web, MCP, renderer, theme, index, session, update, aggregation)
- README lacked current feature set and accurate CLI usage
- No ADRs existed for major architectural decisions made in recent releases
- CONTRIBUTING guide was outdated with missing build commands and conventions